### PR TITLE
Add es2022 lib

### DIFF
--- a/frontend.json
+++ b/frontend.json
@@ -6,7 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "lib": ["dom", "es5", "es6", "es2015", "es7", "es2018", "es2021"],
+    "lib": ["es5", "es6", "es2015", "es7", "es2018", "es2021", "es2022.full"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
Why?
To provide full support for es2022 library (including dom, dom.iterable and few side libs that might be useful like for instance: webworker_.importscript_.

Lib reference:
https://github.com/microsoft/TypeScript/blob/main/lib/lib.es2022.full.d.ts